### PR TITLE
fix(search): fix single-value substr search

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -22,10 +22,19 @@ func (s *Schema) SubstringMatch(q *Query, val string, i int) {
 		q.Query += fmt.Sprintf("e.attrs_norm->>'%s' ILIKE :%s", s.Name, paramKey)
 	} else {
 		if s.IsCaseIgnoreSubstr() {
-			//exists( select 1 from jsonb_array_elements_text(attrs_norm->'uid') as a where  a like 'user111%')
-			q.Query += fmt.Sprintf("EXISTS ( SELECT 1 FROM jsonb_array_elements_text(e.attrs_norm->'%s') AS attr WHERE attr LIKE :%s )", s.Name, paramKey)
+			if s.SingleValue {
+				q.Query += fmt.Sprintf("e.attrs_norm->>'%s' LIKE :%s", s.Name, paramKey)
+			} else {
+				//exists( select 1 from jsonb_array_elements_text(attrs_norm->'uid') as a where  a like 'user111%')
+				q.Query += fmt.Sprintf("EXISTS ( SELECT 1 FROM jsonb_array_elements_text(e.attrs_norm->'%s') AS attr WHERE attr LIKE :%s )", s.Name, paramKey)
+			}
 		} else {
-			q.Query += fmt.Sprintf("EXISTS ( SELECT 1 FROM jsonb_array_elements_text(e.attrs_norm->'%s') AS attr WHERE attr LIKE :%s )", s.Name, paramKey)
+			if s.SingleValue {
+				q.Query += fmt.Sprintf("e.attrs_norm->>'%s' LIKE :%s", s.Name, paramKey)
+			} else {
+				//exists( select 1 from jsonb_array_elements_text(attrs_norm->'uid') as a where  a like 'user111%')
+				q.Query += fmt.Sprintf("EXISTS ( SELECT 1 FROM jsonb_array_elements_text(e.attrs_norm->'%s') AS attr WHERE attr LIKE :%s )", s.Name, paramKey)
+			}
 		}
 	}
 	q.Params[paramKey] = sv.Norm()[0]


### PR DESCRIPTION
Note: To use index search, create the index on postgreSQL like:
`using btree ((attrs->>'employeeNumber') text_pattern_ops)`
or
`using gin ((attrs->>'employeeNumber') gin_trgm_ops)`.